### PR TITLE
Fix typo queryDetails -> getDetails in README.

### DIFF
--- a/v3/README.md
+++ b/v3/README.md
@@ -248,7 +248,7 @@ Full example
             }
             
 			// Click on Query Details button
-			function queryDetails(){
+			function getDetails(){
 				// Query the store for the product details
 				inappbilling.getProductDetails(successHandler, errorHandler, ["gas","infinite_gas"]);
 				


### PR DESCRIPTION
Example code calls nonexistent function.
