### PR TITLE
public license key is now configurable

### DIFF
--- a/v3/README.md
+++ b/v3/README.md
@@ -75,14 +75,21 @@ It contains:
 ```
 
 ### Finish setting up your app
-* Create a release apk of your app and sign it. 
-* Create a new application in the Developer Console. 
-* Upload your apk 
+* Create a release apk of your app and sign it.
+* Create a new application in the Developer Console.
+* Upload your apk
 * Enter the app description, logo, etc. then click on save
 * Add in-app purchases items from the Developer Console (activate them but do not publish the app)
 * Click on Services and APIs to get your public license key
-* In src/android/com/smartmobilesoftware/inappbilling open InAppBillingPlugin.java
-	* Add your public key (base64EncodedPublicKey)
+* Create `res/values/billing_key.xml`, and add your public key as follows:
+
+```
+<?xml version='1.0' encoding='utf-8'?>
+<resources>
+    <string name="billing_key">MIIBIjANBgk...AQAB</string>
+</resources>
+```
+
 * Wait 6-8 hours
 * Install the signed app on your test device in release mode. The Google Account on the test device should not be the same as the developer account).
 * Read carefully the Google testing guide to learn how to test your app : http://developer.android.com/guide/google/play/billing/billing_testing.html

--- a/v3/src/android/com/smartmobilesoftware/inappbilling/InAppBillingPlugin.java
+++ b/v3/src/android/com/smartmobilesoftware/inappbilling/InAppBillingPlugin.java
@@ -28,32 +28,19 @@ import android.util.Log;
 public class InAppBillingPlugin extends CordovaPlugin {
 	private final Boolean ENABLE_DEBUG_LOGGING = true;
 	private final String TAG = "CORDOVA_BILLING";
-	
-	
-	/* base64EncodedPublicKey should be YOUR APPLICATION'S PUBLIC KEY
-     * (that you got from the Google Play developer console). This is not your
-     * developer public key, it's the *app-specific* public key.
-     *
-     * Instead of just storing the entire literal string here embedded in the
-     * program,  construct the key at runtime from pieces or
-     * use bit manipulation (for example, XOR with some other string) to hide
-     * the actual key.  The key itself is not secret information, but we don't
-     * want to make it easy for an attacker to replace the public key with one
-     * of their own and then fake messages from the server.
-     */
-    private final String base64EncodedPublicKey = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAkYbZ4R1GpZTO1GAA2FK6iC0QdXY56GT5oQtmsovDnPBALuSQ2Y02HVKh12E3r36GLzDjtyoJnNNq5UQf2jOblWxzwYHAsjl4nzhmkE7I66Twnn8G/ynqbVZxiotjSoT9L6B3RUI5vSy18ewLfxYgXq6gr46SsAa3N6urr2Wjbp5Z3rhv1LfzFcUrb2sAzy4T6QkDN9ybwYJt1X6ig58khduhh5KKjVIVGKlV51ewi9sCUGoex3F2sW/qll1mMKSXWe9qvkDKUug3dTdp2Acns/wbQVWcOGO6nwoFBR8VXPchIvHfoNmHb9eFWCW/cIlvzVipA3wOXCFPn0jwsUkq/QIDAQAB";
-    
+
+
     // (arbitrary) request code for the purchase flow
     static final int RC_REQUEST = 10001;
-    
+
     // The helper object
     IabHelper mHelper;
-    
+
     // A quite up to date inventory of available items and purchase items
-    Inventory myInventory; 
-    
+    Inventory myInventory;
+
     CallbackContext callbackContext;
-    
+
 	@Override
 	/**
 	 * Called by each javascript plugin function
@@ -121,30 +108,33 @@ public class InAppBillingPlugin extends CordovaPlugin {
 		} catch (JSONException e){
 			callbackContext.error(e.getMessage());
 		}
-		
+
 		// Method not found
 		return isValidAction;
 	}
-	
+
 	// Initialize the plugin
 	private void init(final List<String> skus){
 		Log.d(TAG, "init start");
 		// Some sanity checks to see if the developer (that's you!) really followed the
         // instructions to run this plugin
-	 	if (base64EncodedPublicKey.contains("CONSTRUCT_YOUR")) 
+                int billingKey = cordova.getActivity().getResources().getIdentifier("billing_key", "string", cordova.getActivity().getPackageName());
+                String base64EncodedPublicKey = cordova.getActivity().getString(billingKey);
+
+	 	if (base64EncodedPublicKey.contains("CONSTRUCT_YOUR"))
 	 		throw new RuntimeException("Please put your app's public key in InAppBillingPlugin.java. See ReadMe.");
-	 	
+
 	 	// Create the helper, passing it our context and the public key to verify signatures with
         Log.d(TAG, "Creating IAB helper.");
         mHelper = new IabHelper(cordova.getActivity().getApplicationContext(), base64EncodedPublicKey);
-        
+
         // enable debug logging (for a production application, you should set this to false).
         mHelper.enableDebugLogging(ENABLE_DEBUG_LOGGING);
-        
+
         // Start setup. This is asynchronous and the specified listener
         // will be called once setup completes.
         Log.d(TAG, "Starting setup.");
-        
+
         mHelper.startSetup(new IabHelper.OnIabSetupFinishedListener() {
             public void onIabSetupFinished(IabResult result) {
                 Log.d(TAG, "Setup finished.");


### PR DESCRIPTION
It would be nice not having to alter the source code in order to configure the license key. This patch moves the license key from the Java code into a string resource.
