### PR TITLE
Allow to specify license key via plugin parameter

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -18,6 +18,8 @@
 	
     <!-- android -->
     <platform name="android">
+        <preference name="BILLING_KEY" />
+        
         <js-module src="v3/www/inappbilling.js" name="InAppBillingPlugin">
             <clobbers target="inappbilling" />
         </js-module>
@@ -33,7 +35,12 @@
 				<param name="android-package" value="com.smartmobilesoftware.inappbilling.InAppBillingPlugin"/>
 			</feature>
         </config-file>
-        
+
+        <source-file src="v3/res/values/billing_key_param.xml" target-dir="res/values/" />
+        <config-file target="res/values/billing_key_param.xml" parent="/*">
+            <string name="billing_key_param">$BILLING_KEY</string>
+        </config-file>
+
         <!-- In-app Billing Library -->
 		<source-file src="v3/src/android/com/android/vending/billing/IInAppBillingService.aidl" target-dir="src/com/android/vending/billing" />
 

--- a/v3/README.md
+++ b/v3/README.md
@@ -29,11 +29,11 @@ We recommend this way to install the plugin into your project.
 1. Clone this project into your repository
 2. Run at the root of your project:  
 ```
-    cordova plugin add /path/to/your/cloned/plugin/AndroidInAppBilling/v3
+    cordova plugin add /path/to/your/cloned/plugin/AndroidInAppBilling/v3 --variable BILLING_KEY="MIIBIjANBgk...AQAB"
 ```  
 or  
 ```
-    phonegap local plugin add /path/to/your/cloned/plugin/AndroidInAppBilling/v3
+    phonegap local plugin add /path/to/your/cloned/plugin/AndroidInAppBilling/v3 --variable BILLING_KEY="MIIBIjANBgk...AQAB"
 ```
 
 ### Manually
@@ -81,13 +81,12 @@ It contains:
 * Enter the app description, logo, etc. then click on save
 * Add in-app purchases items from the Developer Console (activate them but do not publish the app)
 * Click on Services and APIs to get your public license key
-* Create `res/values/billing_key.xml`, and add your public key as follows:
+* For PhoneGap build, configure the plugin with a parameter in your `config.xml` file
 
-```
-<?xml version='1.0' encoding='utf-8'?>
-<resources>
-    <string name="billing_key">MIIBIjANBgk...AQAB</string>
-</resources>
+```xml
+<gap:plugin name="com.smartmobilesoftware.inappbilling">
+    <param name="BILLING_KEY" value="MIIBIjANBgk...AQAB" />
+</gap:plugin>
 ```
 
 * Wait 6-8 hours

--- a/v3/plugin.xml
+++ b/v3/plugin.xml
@@ -18,6 +18,8 @@
 	
     <!-- android -->
     <platform name="android">
+        <preference name="BILLING_KEY" />
+
         <js-module src="www/inappbilling.js" name="InAppBillingPlugin">
             <clobbers target="inappbilling" />
         </js-module>
@@ -33,7 +35,12 @@
 				<param name="android-package" value="com.smartmobilesoftware.inappbilling.InAppBillingPlugin"/>
 			</feature>
         </config-file>
-        
+
+        <source-file src="res/values/billing_key_param.xml" target-dir="res/values/" />
+        <config-file target="res/values/billing_key_param.xml" parent="/*">
+            <string name="billing_key_param">$BILLING_KEY</string>
+        </config-file>
+
         <!-- In-app Billing Library -->
 		<source-file src="src/android/com/android/vending/billing/IInAppBillingService.aidl" target-dir="src/com/android/vending/billing" />
 

--- a/v3/res/values/billing_key_param.xml
+++ b/v3/res/values/billing_key_param.xml
@@ -1,0 +1,3 @@
+<?xml version='1.0' encoding='utf-8'?>
+<resources>
+</resources>

--- a/v3/src/android/com/smartmobilesoftware/inappbilling/InAppBillingPlugin.java
+++ b/v3/src/android/com/smartmobilesoftware/inappbilling/InAppBillingPlugin.java
@@ -113,16 +113,25 @@ public class InAppBillingPlugin extends CordovaPlugin {
 		return isValidAction;
 	}
 
+    private String getPublicKey() {
+        int billingKeyFromParam = cordova.getActivity().getResources().getIdentifier("billing_key_param", "string", cordova.getActivity().getPackageName());
+
+        if(billingKeyFromParam > 0) {
+            return cordova.getActivity().getString(billingKeyFromParam);
+        }
+
+        int billingKey = cordova.getActivity().getResources().getIdentifier("billing_key", "string", cordova.getActivity().getPackageName());
+        return cordova.getActivity().getString(billingKey);
+    }
+
 	// Initialize the plugin
 	private void init(final List<String> skus){
 		Log.d(TAG, "init start");
-		// Some sanity checks to see if the developer (that's you!) really followed the
-        // instructions to run this plugin
-                int billingKey = cordova.getActivity().getResources().getIdentifier("billing_key", "string", cordova.getActivity().getPackageName());
-                String base64EncodedPublicKey = cordova.getActivity().getString(billingKey);
 
-	 	if (base64EncodedPublicKey.contains("CONSTRUCT_YOUR"))
-	 		throw new RuntimeException("Please put your app's public key in InAppBillingPlugin.java. See ReadMe.");
+        String base64EncodedPublicKey = getPublicKey();
+
+	 	if (base64EncodedPublicKey.isEmpty())
+	 		throw new RuntimeException("Please install the plugin supplying your Android license key. See README.");
 
 	 	// Create the helper, passing it our context and the public key to verify signatures with
         Log.d(TAG, "Creating IAB helper.");


### PR DESCRIPTION
As requested in #31 PGB currently does not allow customizing any steps of the build process, thus preventing the use of this plugin because there would be no way to customize or provide the Android license key.

This pull request changes the installation procedure of the plugin **requiring** to provide the license key upon installation (when installing using the cordova cli) and upon configuration in the config.xml file (when configuring for PGB). The changes are minimal although they lead to a different installation procedure which is not compatible anymore with the previous one, based on copying the res xml file to the platforms folder (I tried to figure out whether it was possible to keep a backwards compatible way to install the plugin but that doesn't seem to be possible).
