### PR TITLE
Add `signature`, `receipt` to purchases

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,49 +29,49 @@ We recommend this way to install the plugin into your project.
 1. Clone this project into your repository
 2. Run at the root of your project:  
 ```
-    cordova plugin add /path/to/your/cloned/plugin/AndroidInAppBilling --variable BILLING_KEY="MIIBIjANBgk...AQAB"
+cordova plugin add /path/to/your/cloned/plugin/AndroidInAppBilling --variable BILLING_KEY="MIIBIjANBgk...AQAB"
 ```  
 or  
 ```
-    phonegap local plugin add /path/to/your/cloned/plugin/AndroidInAppBilling --variable BILLING_KEY="MIIBIjANBgk...AQAB"
+phonegap local plugin add /path/to/your/cloned/plugin/AndroidInAppBilling --variable BILLING_KEY="MIIBIjANBgk...AQAB"
 ```
 
 ### Manually
 
-The manual steps are not working on Phonegap 3.1+. Theses steps are not maintained anymore. Check the [issue #32](_https://github.com/poiuytrez/AndroidInAppBilling/issues/32) for more info. 
+The manual steps are not working on Phonegap 3.1+. Theses steps are not maintained anymore. Check the [issue #32](_https://github.com/poiuytrez/AndroidInAppBilling/issues/32) for more info.
 
 * Add in your `src` folder the `src/android/com` folder  
 It contains:
     * [Google Play In-app Billing library]( http://developer.android.com/guide/google/play/billing/billing_overview.html)
-	* Phonegap InAppBillingPlugin
+    * Phonegap InAppBillingPlugin
 * Create a `plugins` folder in your project's `www` folder if it does not exist.
 * Create a `com.smartmobilesoftware.inappbilling` folder inside the `plugins` folder.
 * Copy `www/inappbilling.js` into `<path to project>/www/plugins/com.smartmobilesoftware.inappbilling/www`
 * In res/xml/config.xml, add  
 
 ```xml  
-<feature name="InAppBillingPlugin">   
+<feature name="InAppBillingPlugin">
       <param name="android-package" value="com.smartmobilesoftware.inappbilling.InAppBillingPlugin"/>  
 </feature>  
 ```
 * Open the AndroidManifest.xml of your application
-	* add this permission  
+    * add this permission  
 `<uses-permission android:name="com.android.vending.BILLING" />`
 * Create a new file named `Phonegap_plugins.js` in the `<path to project>/www` folder if it does not exist.
 * Edit `Phonegap_plugins.js` and add a reference to the plugin to automatically load it:
 
 ```javascript
-    Phonegap.define('Phonegap/plugin_list', function(require, exports, module) {
+Phonegap.define('Phonegap/plugin_list', function(require, exports, module) {
     module.exports = [
         {
             "file": "plugins/com.smartmobilesoftware.inappbilling/www/inappbilling.js",
             "id": "com.smartmobilesoftware.inappbilling.InAppBillingPlugin",
             "clobbers": [
                 "inappbilling"
-	    ]
-    	}
+            ]
+        }
     ]
-    });
+});
 ```
 
 ### Finish setting up your app
@@ -96,15 +96,15 @@ It contains:
 Usage
 -------
 #### Initialization
-Initialize the billing plugin. The plugin must be inialized before calling any other methods. 
+Initialize the billing plugin. The plugin must be inialized before calling any other methods.
 
     inappbilling.init(success, error, options)
 parameters
 * success : The success callback.
 * error : The error callback.
 * options : Sets the options for the plugin
-	* Available Options :
-		* showLog [true,false] : showLog enables plugin JS debug messages. Default : true
+    * Available Options :
+        * showLog [true,false] : showLog enables plugin JS debug messages. Default : true
 
 #### Optional Initialization
 
@@ -113,16 +113,16 @@ parameters
 * success : The success callback.
 * error : The error callback.
 * options : Sets the options for the plugin
-	* Available Options :
-		* showLog [true,false] : showLog enables plugin JS debug messages. Default : true
+    * Available Options :
+        * showLog [true,false] : showLog enables plugin JS debug messages. Default : true
 * skus : string or string[] of product skus. ie. "prod1" or ["prod1","prod2]
 
 #### Retrieve owned products
 The list of owned products are retrieved from the local database.
 
-	inappbilling.getPurchases(success, fail)
+    inappbilling.getPurchases(success, fail)
 parameters
-* success : The success callback. It provides an array of json object representing the owned products as a parameter. Example: 
+* success : The success callback. It provides an array of json object representing the owned products as a parameter. Example:
 
  [{"purchaseToken":"tokenabc","developerPayload":"mypayload1",
    "packageName":"com.example.MyPackage","purchaseState":0,"orderId":"12345.6789",
@@ -156,7 +156,7 @@ parameters
 #### Subscribe
 Subscribe to an item
 
-	inappbilling.subscribe(success, fail, subcriptionId)
+    inappbilling.subscribe(success, fail, subcriptionId)
 parameters
 * success : The success callback.
 * error : The error callback.
@@ -169,12 +169,12 @@ Consume an item. You can consume an item that you own. Example of consumable ite
 parameters
 * success : The success callback. It provides a json object with the transaction details. Example :  
 {
-	"orderId":"12999763169054705758.1321583410745163",
-	"packageName":"com.smartmobilesoftware.trivialdrivePhonegap",
-	"productId":"gas",
-	"purchaseTime":1369402680000,
-	"purchaseState":0,
-	"purchaseToken":"ccroltzduesqaxtuuopnqcsc.AO-J1Oyao-HWamJo_6a4OQSlhflhOjQgYWbb-99VF2gcj_CB1dd1Sfp5d-olgouTWJ13Q6vc5zbl0SFfpofmpyuyeEmJ"
+    "orderId":"12999763169054705758.1321583410745163",
+    "packageName":"com.smartmobilesoftware.trivialdrivePhonegap",
+    "productId":"gas",
+    "purchaseTime":1369402680000,
+    "purchaseState":0,
+    "purchaseToken":"ccroltzduesqaxtuuopnqcsc.AO-J1Oyao-HWamJo_6a4OQSlhflhOjQgYWbb-99VF2gcj_CB1dd1Sfp5d-olgouTWJ13Q6vc5zbl0SFfpofmpyuyeEmJ"
 }
 
 * error : The error callback.
@@ -183,7 +183,7 @@ parameters
 #### Get Product(s) Details
 Load the available product(s) to inventory. Not needed if you use the init(success, error, options, skus) method.  Can be used to update inventory if you need to add more skus.
 
-		inappbilling.getProductDetails(success, fail, skus)
+    inappbilling.getProductDetails(success, fail, skus)
 * success : The success callback.
 * error : The error callback.
 * skus : string or string[] of product skus. ie. "prod1" or ["prod1","prod2]
@@ -191,16 +191,16 @@ Load the available product(s) to inventory. Not needed if you use the init(succe
 #### Get Available Product(s)
 The list of the available product(s) in inventory.
 
-		inappbilling.getAvailableProducts(success, fail) 
+    inappbilling.getAvailableProducts(success, fail)
 * success : The success callback. It provides a json array of the list of owned products as a parameter. Example :  
 {index:
 {
-	"title":"Infinite Gas",
-	"price":"2.99",
-	"type":"subs",
-	"description":"Lots of Infinite Gas",
-	"productId":"infinite_gas",
-	"price_currency_code":"USD"
+    "title":"Infinite Gas",
+    "price":"2.99",
+    "type":"subs",
+    "description":"Lots of Infinite Gas",
+    "productId":"infinite_gas",
+    "price_currency_code":"USD"
 }}
 
 * error : The error callback.
@@ -209,22 +209,22 @@ The list of the available product(s) in inventory.
 Quick example
 ---------------
 ```javascript
-inappbilling.init(successInit,errorCallback, {showLog:true})
+inappbilling.init(successInit, errorCallback, {showLog:true})
 
-function successInit(result) {    
-	// display the extracted text   
-	alert(result); 
-	// make the purchase
-	inappbilling.buy(successPurchase, errorCallback,"gas");
-	
-}    
+function successInit(result) {
+    // display the extracted text
+    alert(result);
+    // make the purchase
+    inappbilling.buy(successPurchase, errorCallback, "gas");
+}
+
 function errorCallback(error) {
-   alert(error); 
-} 
+   alert(error);
+}
 
 function successPurchase(productId) {
    alert("Your item has been purchased!");
-} 
+}
 ```
 
 Full example
@@ -232,48 +232,45 @@ Full example
 ```html
 <!DOCTYPE HTML>
 <html>
-	<head>
-		<title>In App Billing</title>
-		<script type="text/javascript" charset="utf-8" src="phonegap.js"></script>
-		<script type="text/javascript" charset="utf-8" src="inappbilling.js"></script>
-		<script type="text/javascript" charset="utf-8">
-			function successHandler (result) {
+    <head>
+        <title>In App Billing</title>
+        <script type="text/javascript" charset="utf-8" src="phonegap.js"></script>
+        <script type="text/javascript" charset="utf-8" src="inappbilling.js"></script>
+        <script type="text/javascript" charset="utf-8">
+            function successHandler (result) {
                 var strResult = "";
                 if(typeof result === 'object') {
                     strResult = JSON.stringify(result);
                 } else {
                     strResult = result;
                 }
-                alert("SUCCESS: \r\n"+strResult );
+                alert("SUCCESS: \r\n" + strResult);
             }
-			
-			function errorHandler (error) {
-			    alert("ERROR: \r\n"+error );
-			}
+
+            function errorHandler (error) {
+                alert("ERROR: \r\n" + error);
+            }
 
             // Click on init button
-			function init(){
-				// Initialize the billing plugin
-				inappbilling.init(successHandler, errorHandler, {showLog:true});
-			}
+            function init(){
+                // Initialize the billing plugin
+                inappbilling.init(successHandler, errorHandler, {showLog:true});
+            }
 
-			// Click on purchase button
-			function buy(){
-				// make the purchase
-				inappbilling.buy(successHandler, errorHandler,"gas");
-				
-			}
-			
-			// Click on ownedProducts button
-			function ownedProducts(){
-				// Initialize the billing plugin
-				inappbilling.getPurchases(successHandler, errorHandler);
-				
-			}
+            // Click on purchase button
+            function buy(){
+                // make the purchase
+                inappbilling.buy(successHandler, errorHandler, "gas");
+            }
+
+            // Click on ownedProducts button
+            function ownedProducts(){
+                // Initialize the billing plugin
+                inappbilling.getPurchases(successHandler, errorHandler);
+            }
 
             // Click on Consume purchase button
             function consumePurchase(){
-
                 inappbilling.consumePurchase(successHandler, errorHandler, "gas");
             }
 
@@ -281,30 +278,25 @@ Full example
             function subscribe(){
                 // make the purchase
                 inappbilling.subscribe(successHandler, errorHandler,"infinite_gas");
-
             }
-            
-			// Click on Query Details button
-			function getDetails(){
-				// Query the store for the product details
-				inappbilling.getProductDetails(successHandler, errorHandler, ["gas","infinite_gas"]);
-				
-			}
-			
-			// Click on Get Available Products button
-			function getAvailable(){
-				// Get the products available for purchase.
-				inappbilling.getAvailableProducts(successHandler, errorHandler);
-				
-			}						
-			
+
+            // Click on Query Details button
+            function getDetails(){
+                // Query the store for the product details
+                inappbilling.getProductDetails(successHandler, errorHandler, ["gas","infinite_gas"]);
+            }
+
+            // Click on Get Available Products button
+            function getAvailable(){
+                // Get the products available for purchase.
+                inappbilling.getAvailableProducts(successHandler, errorHandler);
+            }
         </script>
-		
-	</head>
-	<body>
-		<h1>Hello World</h1>
-		<button onclick="init();">Initalize the billing plugin</button>
-		<button onclick="buy();">Purchase</button>
+    </head>
+    <body>
+        <h1>Hello World</h1>
+        <button onclick="init();">Initalize the billing plugin</button>
+        <button onclick="buy();">Purchase</button>
         <button onclick="ownedProducts();">Owned products</button>
         <button onclick="consumePurchase();">Consume purchase</button>
         <button onclick="subscribe();">Subscribe</button>
@@ -319,7 +311,7 @@ Common issues
 If you have an issue, make sure that you can answer to theses questions:  
 Did you create your item in the Developer Console?  
 Is the id for your item the same in the Developer Console and in your app?  
-Is your item active? 
+Is your item active?
 Have you uploaded and published your apk in the alpha or beta channels?  You can no longer test in app purchases with an apk in draft mode.
 Have you waited at least a few hours since you activated your item and published your apk on the Developer Console?  
 Are you using a different Google account than your developer account to make the purchase?
@@ -328,7 +320,7 @@ Using the Google account, did you follow the link that appears in the channel wh
 Are you testing on a real device, rather than the emulator?  
 Are you using a signed apk?  
 Is the version code of your app the same as the one uploaded on the Developer Console?  
-  
+
 If any of these questions is answered with a "no", you probably need to fix that.  
 
 

--- a/README.md
+++ b/README.md
@@ -126,10 +126,12 @@ parameters
 
  [{"purchaseToken":"tokenabc","developerPayload":"mypayload1",
    "packageName":"com.example.MyPackage","purchaseState":0,"orderId":"12345.6789",
-   "purchaseTime":1382517909216,"productId":"example_subscription"},
+   "purchaseTime":1382517909216,"productId":"example_subscription",
+   "receipt": "{...}","signature": "sq45GSgHGjJSSHJKUHI"},
   {"purchaseToken":"tokenxyz","developerPayload":"mypayload2",
    "packageName":"com.example.MyPacakge","purchaseState":0,"orderId":"98765.4321",
-   "purchaseTime":1382435077000,"productId":"example_product"}]
+   "purchaseTime":1382435077000,"productId":"example_product",
+   "receipt": "{...}","signature": "qs54SGHgjGSJHSKJHIU"}]
 
 * error : The error callback.
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -7,7 +7,7 @@
 
     <name>Android InAppBilling</name>
     <description>Use this In-app Billing plugin to sell digital goods, including one-time items and recurring subscriptions from your Cordova application. Main repo with full documentation located at: https://github.com/poiuytrez/AndroidInAppBilling</description>
-    
+
     <author>Guillaume Charhon - Smart Mobile Software</author>
     <keywords>billing,in-app,inapp,purchase,credit</keywords>
     <license>MIT</license>
@@ -15,7 +15,7 @@
     <engines>
       <engine name="cordova" version=">=3.0.0" />
     </engines>
-	
+
     <!-- android -->
     <platform name="android">
         <preference name="BILLING_KEY" />
@@ -24,16 +24,16 @@
             <clobbers target="inappbilling" />
         </js-module>
 
-		<config-file target="AndroidManifest.xml" parent="/manifest">
+        <config-file target="AndroidManifest.xml" parent="/manifest">
             <!-- InApp Billing -->
-			<uses-permission android:name="com.android.vending.BILLING" />
+            <uses-permission android:name="com.android.vending.BILLING" />
         </config-file>
 
         <!-- Cordova >= 3.0.0 -->
         <config-file target="res/xml/config.xml" parent="/*">
-            <feature name="InAppBillingPlugin">   
-				<param name="android-package" value="com.smartmobilesoftware.inappbilling.InAppBillingPlugin"/>
-			</feature>
+            <feature name="InAppBillingPlugin">
+                <param name="android-package" value="com.smartmobilesoftware.inappbilling.InAppBillingPlugin"/>
+            </feature>
         </config-file>
 
         <source-file src="res/values/billing_key_param.xml" target-dir="res/values/" />
@@ -42,19 +42,19 @@
         </config-file>
 
         <!-- In-app Billing Library -->
-		<source-file src="src/android/com/android/vending/billing/IInAppBillingService.aidl" target-dir="src/com/android/vending/billing" />
+        <source-file src="src/android/com/android/vending/billing/IInAppBillingService.aidl" target-dir="src/com/android/vending/billing" />
 
         <!-- cordova plugin src files -->
         <source-file src="src/android/com/smartmobilesoftware/inappbilling/InAppBillingPlugin.java" target-dir="src/com/smartmobilesoftware/inappbilling" />
 
-		<source-file src="src/android/com/smartmobilesoftware/util/Base64.java" target-dir="src/com/smartmobilesoftware/util" />
-		<source-file src="src/android/com/smartmobilesoftware/util/Base64DecoderException.java" target-dir="src/com/smartmobilesoftware/util" />
-		<source-file src="src/android/com/smartmobilesoftware/util/IabException.java" target-dir="src/com/smartmobilesoftware/util" />
-		<source-file src="src/android/com/smartmobilesoftware/util/IabHelper.java" target-dir="src/com/smartmobilesoftware/util" />
-		<source-file src="src/android/com/smartmobilesoftware/util/IabResult.java" target-dir="src/com/smartmobilesoftware/util" />
-		<source-file src="src/android/com/smartmobilesoftware/util/Inventory.java" target-dir="src/com/smartmobilesoftware/util" />
-		<source-file src="src/android/com/smartmobilesoftware/util/Purchase.java" target-dir="src/com/smartmobilesoftware/util" />
-		<source-file src="src/android/com/smartmobilesoftware/util/Security.java" target-dir="src/com/smartmobilesoftware/util" />
-		<source-file src="src/android/com/smartmobilesoftware/util/SkuDetails.java" target-dir="src/com/smartmobilesoftware/util" />
+        <source-file src="src/android/com/smartmobilesoftware/util/Base64.java" target-dir="src/com/smartmobilesoftware/util" />
+        <source-file src="src/android/com/smartmobilesoftware/util/Base64DecoderException.java" target-dir="src/com/smartmobilesoftware/util" />
+        <source-file src="src/android/com/smartmobilesoftware/util/IabException.java" target-dir="src/com/smartmobilesoftware/util" />
+        <source-file src="src/android/com/smartmobilesoftware/util/IabHelper.java" target-dir="src/com/smartmobilesoftware/util" />
+        <source-file src="src/android/com/smartmobilesoftware/util/IabResult.java" target-dir="src/com/smartmobilesoftware/util" />
+        <source-file src="src/android/com/smartmobilesoftware/util/Inventory.java" target-dir="src/com/smartmobilesoftware/util" />
+        <source-file src="src/android/com/smartmobilesoftware/util/Purchase.java" target-dir="src/com/smartmobilesoftware/util" />
+        <source-file src="src/android/com/smartmobilesoftware/util/Security.java" target-dir="src/com/smartmobilesoftware/util" />
+        <source-file src="src/android/com/smartmobilesoftware/util/SkuDetails.java" target-dir="src/com/smartmobilesoftware/util" />
     </platform>
 </plugin>

--- a/src/android/com/smartmobilesoftware/inappbilling/InAppBillingPlugin.java
+++ b/src/android/com/smartmobilesoftware/inappbilling/InAppBillingPlugin.java
@@ -26,8 +26,8 @@ import android.content.Intent;
 import android.util.Log;
 
 public class InAppBillingPlugin extends CordovaPlugin {
-	private final Boolean ENABLE_DEBUG_LOGGING = true;
-	private final String TAG = "CORDOVA_BILLING";
+    private final Boolean ENABLE_DEBUG_LOGGING = true;
+    private final String TAG = "CORDOVA_BILLING";
 
 
     // (arbitrary) request code for the purchase flow
@@ -41,77 +41,77 @@ public class InAppBillingPlugin extends CordovaPlugin {
 
     CallbackContext callbackContext;
 
-	@Override
-	/**
-	 * Called by each javascript plugin function
-	 */
-	public boolean execute(String action, JSONArray data, final CallbackContext callbackContext) {
-		this.callbackContext = callbackContext;
-		// Check if the action has a handler
-		Boolean isValidAction = true;
-		
-		try {
-			// Action selector
-			if ("init".equals(action)) {
-				final List<String> sku = new ArrayList<String>();
-				if(data.length() > 0){
-					JSONArray jsonSkuList = new JSONArray(data.getString(0));
-					int len = jsonSkuList.length();
-					Log.d(TAG, "Num SKUs Found: "+len);
-	   			 for (int i=0;i<len;i++){
-	    				sku.add(jsonSkuList.get(i).toString());
-						Log.d(TAG, "Product SKU Added: "+jsonSkuList.get(i).toString());
-	   			 }
-				}
-				// Initialize
-				init(sku);
-			} else if ("getPurchases".equals(action)) {
-				// Get the list of purchases
-				JSONArray jsonSkuList = new JSONArray();
-				jsonSkuList = getPurchases();
-	            // Call the javascript back
-	            callbackContext.success(jsonSkuList);
-			} else if ("buy".equals(action)) {
-				// Buy an item
-				// Get Product Id 
-				final String sku = data.getString(0);
-				buy(sku);
-			} else if ("subscribe".equals(action)) {
-				// Subscribe to an item
-				// Get Product Id 
-				final String sku = data.getString(0);
-				subscribe(sku);
-			} else if ("consumePurchase".equals(action)) {
-				consumePurchase(data);
-			} else if ("getAvailableProducts".equals(action)) {
-				// Get the list of purchases
-				JSONArray jsonSkuList = new JSONArray();
-				jsonSkuList = getAvailableProducts();
-	            // Call the javascript back
-	            callbackContext.success(jsonSkuList);
-			} else if ("getProductDetails".equals(action)) {
-				JSONArray jsonSkuList = new JSONArray(data.getString(0));
-				final List<String> sku = new ArrayList<String>();			
-				int len = jsonSkuList.length();
-				Log.d(TAG, "Num SKUs Found: "+len);
-   			 for (int i=0;i<len;i++){
-    				sku.add(jsonSkuList.get(i).toString());
-					Log.d(TAG, "Product SKU Added: "+jsonSkuList.get(i).toString());
-   			 }
-				getProductDetails(sku);				
-			} else {
-				// No handler for the action
-				isValidAction = false;
-			}
-		} catch (IllegalStateException e){
-			callbackContext.error(e.getMessage());
-		} catch (JSONException e){
-			callbackContext.error(e.getMessage());
-		}
+    @Override
+    /**
+     * Called by each javascript plugin function
+     */
+    public boolean execute(String action, JSONArray data, final CallbackContext callbackContext) {
+        this.callbackContext = callbackContext;
+        // Check if the action has a handler
+        Boolean isValidAction = true;
 
-		// Method not found
-		return isValidAction;
-	}
+        try {
+            // Action selector
+            if ("init".equals(action)) {
+                final List<String> sku = new ArrayList<String>();
+                if(data.length() > 0){
+                    JSONArray jsonSkuList = new JSONArray(data.getString(0));
+                    int len = jsonSkuList.length();
+                    Log.d(TAG, "Num SKUs Found: "+len);
+                    for (int i=0;i<len;i++){
+                        sku.add(jsonSkuList.get(i).toString());
+                        Log.d(TAG, "Product SKU Added: "+jsonSkuList.get(i).toString());
+                    }
+                }
+                // Initialize
+                init(sku);
+            } else if ("getPurchases".equals(action)) {
+                // Get the list of purchases
+                JSONArray jsonSkuList = new JSONArray();
+                jsonSkuList = getPurchases();
+                // Call the javascript back
+                callbackContext.success(jsonSkuList);
+            } else if ("buy".equals(action)) {
+                // Buy an item
+                // Get Product Id
+                final String sku = data.getString(0);
+                buy(sku);
+            } else if ("subscribe".equals(action)) {
+                // Subscribe to an item
+                // Get Product Id
+                final String sku = data.getString(0);
+                subscribe(sku);
+            } else if ("consumePurchase".equals(action)) {
+                consumePurchase(data);
+            } else if ("getAvailableProducts".equals(action)) {
+                // Get the list of purchases
+                JSONArray jsonSkuList = new JSONArray();
+                jsonSkuList = getAvailableProducts();
+                // Call the javascript back
+                callbackContext.success(jsonSkuList);
+            } else if ("getProductDetails".equals(action)) {
+                JSONArray jsonSkuList = new JSONArray(data.getString(0));
+                final List<String> sku = new ArrayList<String>();
+                int len = jsonSkuList.length();
+                Log.d(TAG, "Num SKUs Found: "+len);
+                for (int i=0;i<len;i++){
+                    sku.add(jsonSkuList.get(i).toString());
+                    Log.d(TAG, "Product SKU Added: "+jsonSkuList.get(i).toString());
+                }
+                getProductDetails(sku);
+            } else {
+                // No handler for the action
+                isValidAction = false;
+            }
+        } catch (IllegalStateException e){
+            callbackContext.error(e.getMessage());
+        } catch (JSONException e){
+            callbackContext.error(e.getMessage());
+        }
+
+        // Method not found
+        return isValidAction;
+    }
 
     private String getPublicKey() {
         int billingKeyFromParam = cordova.getActivity().getResources().getIdentifier("billing_key_param", "string", cordova.getActivity().getPackageName());
@@ -124,16 +124,16 @@ public class InAppBillingPlugin extends CordovaPlugin {
         return cordova.getActivity().getString(billingKey);
     }
 
-	// Initialize the plugin
-	private void init(final List<String> skus){
-		Log.d(TAG, "init start");
+    // Initialize the plugin
+    private void init(final List<String> skus){
+        Log.d(TAG, "init start");
 
         String base64EncodedPublicKey = getPublicKey();
 
-	 	if (base64EncodedPublicKey.isEmpty())
-	 		throw new RuntimeException("Please install the plugin supplying your Android license key. See README.");
+         if (base64EncodedPublicKey.isEmpty())
+             throw new RuntimeException("Please install the plugin supplying your Android license key. See README.");
 
-	 	// Create the helper, passing it our context and the public key to verify signatures with
+         // Create the helper, passing it our context and the public key to verify signatures with
         Log.d(TAG, "Creating IAB helper.");
         mHelper = new IabHelper(cordova.getActivity().getApplicationContext(), base64EncodedPublicKey);
 
@@ -153,148 +153,148 @@ public class InAppBillingPlugin extends CordovaPlugin {
                     callbackContext.error("Problem setting up in-app billing: " + result);
                     return;
                 }
-                
+
                 // Have we been disposed of in the meantime? If so, quit.
                 if (mHelper == null) {
-                	callbackContext.error("The billing helper has been disposed");
+                    callbackContext.error("The billing helper has been disposed");
                 }
 
                 // Hooray, IAB is fully set up. Now, let's get an inventory of stuff we own.
                 if(skus.size() <= 0){
-					Log.d(TAG, "Setup successful. Querying inventory.");
-                	mHelper.queryInventoryAsync(mGotInventoryListener);
-				}else{
-					Log.d(TAG, "Setup successful. Querying inventory w/ SKUs.");
-					mHelper.queryInventoryAsync(true, skus, mGotInventoryListener);
-				}
-            }			
+                    Log.d(TAG, "Setup successful. Querying inventory.");
+                    mHelper.queryInventoryAsync(mGotInventoryListener);
+                }else{
+                    Log.d(TAG, "Setup successful. Querying inventory w/ SKUs.");
+                    mHelper.queryInventoryAsync(true, skus, mGotInventoryListener);
+                }
+            }
         });
     }
-	
-	// Buy an item
-	private void buy(final String sku){
-		/* TODO: for security, generate your payload here for verification. See the comments on 
-         *        verifyDeveloperPayload() for more info. Since this is a sample, we just use 
+
+    // Buy an item
+    private void buy(final String sku){
+        /* TODO: for security, generate your payload here for verification. See the comments on
+         *        verifyDeveloperPayload() for more info. Since this is a sample, we just use
          *        an empty string, but on a production app you should generate this. */
-		final String payload = "";
-		
-		if (mHelper == null){
-			callbackContext.error("Billing plugin was not initialized");
-			return;
-		}
-		
-		this.cordova.setActivityResultCallback(this);
-		
-		mHelper.launchPurchaseFlow(cordova.getActivity(), sku, RC_REQUEST, 
+        final String payload = "";
+
+        if (mHelper == null){
+            callbackContext.error("Billing plugin was not initialized");
+            return;
+        }
+
+        this.cordova.setActivityResultCallback(this);
+
+        mHelper.launchPurchaseFlow(cordova.getActivity(), sku, RC_REQUEST,
                 mPurchaseFinishedListener, payload);
 
-	}
-	
-	// Buy an item
-	private void subscribe(final String sku){
-		if (mHelper == null){
-			callbackContext.error("Billing plugin was not initialized");
-			return;
-		}
-		if (!mHelper.subscriptionsSupported()) {
+    }
+
+    // Buy an item
+    private void subscribe(final String sku){
+        if (mHelper == null){
+            callbackContext.error("Billing plugin was not initialized");
+            return;
+        }
+        if (!mHelper.subscriptionsSupported()) {
             callbackContext.error("Subscriptions not supported on your device yet. Sorry!");
             return;
         }
-		
-		/* TODO: for security, generate your payload here for verification. See the comments on 
-         *        verifyDeveloperPayload() for more info. Since this is a sample, we just use 
+
+        /* TODO: for security, generate your payload here for verification. See the comments on
+         *        verifyDeveloperPayload() for more info. Since this is a sample, we just use
          *        an empty string, but on a production app you should generate this. */
-		final String payload = "";
-		
-		
-		
-		this.cordova.setActivityResultCallback(this);
+        final String payload = "";
+
+
+
+        this.cordova.setActivityResultCallback(this);
         Log.d(TAG, "Launching purchase flow for subscription.");
 
-		mHelper.launchPurchaseFlow(cordova.getActivity(), sku, IabHelper.ITEM_TYPE_SUBS, RC_REQUEST, mPurchaseFinishedListener, payload);   
-	}
-	
+        mHelper.launchPurchaseFlow(cordova.getActivity(), sku, IabHelper.ITEM_TYPE_SUBS, RC_REQUEST, mPurchaseFinishedListener, payload);
+    }
 
-	// Get the list of purchases
-	private JSONArray getPurchases() throws JSONException {
-		// Get the list of owned items
-		if(myInventory == null){
-			callbackContext.error("Billing plugin was not initialized");
-			return new JSONArray();
-		}
+
+    // Get the list of purchases
+    private JSONArray getPurchases() throws JSONException {
+        // Get the list of owned items
+        if(myInventory == null){
+            callbackContext.error("Billing plugin was not initialized");
+            return new JSONArray();
+        }
         List<Purchase>purchaseList = myInventory.getAllPurchases();
 
         // Convert the java list to json
         JSONArray jsonPurchaseList = new JSONArray();
         for (Purchase p : purchaseList) {
-	        jsonPurchaseList.put(new JSONObject(p.getOriginalJson()));
+            jsonPurchaseList.put(new JSONObject(p.getOriginalJson()));
         }
 
         return jsonPurchaseList;
 
-	}
+    }
 
-	// Get the list of available products
-	private JSONArray getAvailableProducts(){
-		// Get the list of owned items
-		if(myInventory == null){
-			callbackContext.error("Billing plugin was not initialized");
-			return new JSONArray();
-		}
+    // Get the list of available products
+    private JSONArray getAvailableProducts(){
+        // Get the list of owned items
+        if(myInventory == null){
+            callbackContext.error("Billing plugin was not initialized");
+            return new JSONArray();
+        }
         List<SkuDetails>skuList = myInventory.getAllProducts();
-        
-		// Convert the java list to json
-	    JSONArray jsonSkuList = new JSONArray();
-		try{
-	        for (SkuDetails sku : skuList) {
-				Log.d(TAG, "SKUDetails: Title: "+sku.getTitle());
-	        	jsonSkuList.put(sku.toJson());
-	        }
-		}catch (JSONException e){
-			callbackContext.error(e.getMessage());
-		}
-		return jsonSkuList;
-	}
 
-	//Get SkuDetails for skus
-	private void getProductDetails(final List<String> skus){
-		if (mHelper == null){
-			callbackContext.error("Billing plugin was not initialized");
-			return;
-		}
+        // Convert the java list to json
+        JSONArray jsonSkuList = new JSONArray();
+        try{
+            for (SkuDetails sku : skuList) {
+                Log.d(TAG, "SKUDetails: Title: "+sku.getTitle());
+                jsonSkuList.put(sku.toJson());
+            }
+        }catch (JSONException e){
+            callbackContext.error(e.getMessage());
+        }
+        return jsonSkuList;
+    }
 
-		Log.d(TAG, "Beginning Sku(s) Query!");
-		mHelper.queryInventoryAsync(true, skus, mGotDetailsListener);
-	}
-	
-	// Consume a purchase
-	private void consumePurchase(JSONArray data) throws JSONException{
-		
-		if (mHelper == null){
-			callbackContext.error("Did you forget to initialize the plugin?");
-			return;
-		} 
-		
-		String sku = data.getString(0);
-		
-		// Get the purchase from the inventory
-		Purchase purchase = myInventory.getPurchase(sku);
-		if (purchase != null)
-			// Consume it
-			mHelper.consumeAsync(purchase, mConsumeFinishedListener);
-		else
-			callbackContext.error(sku + " is not owned so it cannot be consumed");
-	}
-	
-	// Listener that's called when we finish querying the items and subscriptions we own
+    //Get SkuDetails for skus
+    private void getProductDetails(final List<String> skus){
+        if (mHelper == null){
+            callbackContext.error("Billing plugin was not initialized");
+            return;
+        }
+
+        Log.d(TAG, "Beginning Sku(s) Query!");
+        mHelper.queryInventoryAsync(true, skus, mGotDetailsListener);
+    }
+
+    // Consume a purchase
+    private void consumePurchase(JSONArray data) throws JSONException{
+
+        if (mHelper == null){
+            callbackContext.error("Did you forget to initialize the plugin?");
+            return;
+        }
+
+        String sku = data.getString(0);
+
+        // Get the purchase from the inventory
+        Purchase purchase = myInventory.getPurchase(sku);
+        if (purchase != null)
+            // Consume it
+            mHelper.consumeAsync(purchase, mConsumeFinishedListener);
+        else
+            callbackContext.error(sku + " is not owned so it cannot be consumed");
+    }
+
+    // Listener that's called when we finish querying the items and subscriptions we own
     IabHelper.QueryInventoryFinishedListener mGotInventoryListener = new IabHelper.QueryInventoryFinishedListener() {
         public void onQueryInventoryFinished(IabResult result, Inventory inventory) {
-        	Log.d(TAG, "Inside mGotInventoryListener");
-        	if (hasErrorsAndUpdateInventory(result, inventory)) return;
+            Log.d(TAG, "Inside mGotInventoryListener");
+            if (hasErrorsAndUpdateInventory(result, inventory)) return;
 
             Log.d(TAG, "Query inventory was successful.");
             callbackContext.success();
-            
+
         }
     };
     // Listener that's called when we finish querying the details
@@ -306,7 +306,7 @@ public class InAppBillingPlugin extends CordovaPlugin {
             Log.d(TAG, "Query details was successful.");
 
             List<SkuDetails>skuList = inventory.getAllProducts();
-        
+
             // Convert the java list to json
             JSONArray jsonSkuList = new JSONArray();
             try {
@@ -323,48 +323,48 @@ public class InAppBillingPlugin extends CordovaPlugin {
 
     // Check if there is any errors in the iabResult and update the inventory
     private Boolean hasErrorsAndUpdateInventory(IabResult result, Inventory inventory){
-    	if (result.isFailure()) {
-        	callbackContext.error("Failed to query inventory: " + result);
-        	return true;
+        if (result.isFailure()) {
+            callbackContext.error("Failed to query inventory: " + result);
+            return true;
         }
-        
+
         // Have we been disposed of in the meantime? If so, quit.
         if (mHelper == null) {
-        	callbackContext.error("The billing helper has been disposed");
-        	return true;
+            callbackContext.error("The billing helper has been disposed");
+            return true;
         }
-        
+
         // Update the inventory
         myInventory = inventory;
-        
+
         return false;
     }
-    
+
     // Callback for when a purchase is finished
     IabHelper.OnIabPurchaseFinishedListener mPurchaseFinishedListener = new IabHelper.OnIabPurchaseFinishedListener() {
         public void onIabPurchaseFinished(IabResult result, Purchase purchase) {
             Log.d(TAG, "Purchase finished: " + result + ", purchase: " + purchase);
-            
+
             // Have we been disposed of in the meantime? If so, quit.
             if (mHelper == null) {
-            	callbackContext.error("The billing helper has been disposed");
+                callbackContext.error("The billing helper has been disposed");
             }
-            
+
             if (result.isFailure()) {
-            	callbackContext.error("Error purchasing: " + result);
+                callbackContext.error("Error purchasing: " + result);
                 return;
             }
-            
+
             if (!verifyDeveloperPayload(purchase)) {
-            	callbackContext.error("Error purchasing. Authenticity verification failed.");
+                callbackContext.error("Error purchasing. Authenticity verification failed.");
                 return;
             }
 
             Log.d(TAG, "Purchase successful.");
-            
+
             // add the purchase to the inventory
             myInventory.addPurchase(purchase);
-            
+
             // append the purchase signature & receipt to the json
             try {
                 JSONObject purchaseJsonObject = new JSONObject(purchase.getOriginalJson());
@@ -377,7 +377,7 @@ public class InAppBillingPlugin extends CordovaPlugin {
 
         }
     };
-    
+
     // Called when consumption is complete
     IabHelper.OnConsumeFinishedListener mConsumeFinishedListener = new IabHelper.OnConsumeFinishedListener() {
         public void onConsumeFinished(Purchase purchase, IabResult result) {
@@ -389,23 +389,23 @@ public class InAppBillingPlugin extends CordovaPlugin {
             if (result.isSuccess()) {
                 // successfully consumed, so we apply the effects of the item in our
                 // game world's logic
-            	
+
                 // remove the item from the inventory
-            	myInventory.erasePurchase(purchase.getSku());
+                myInventory.erasePurchase(purchase.getSku());
                 Log.d(TAG, "Consumption successful. .");
-                
+
                 callbackContext.success(purchase.getOriginalJson());
-                
+
             }
             else {
                 callbackContext.error("Error while consuming: " + result);
             }
-            
+
         }
     };
-    
+
     @Override
-	public void onActivityResult(int requestCode, int resultCode, Intent data) {
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
         Log.d(TAG, "onActivityResult(" + requestCode + "," + resultCode + "," + data);
 
         // Pass on the activity result to the helper for handling
@@ -419,49 +419,49 @@ public class InAppBillingPlugin extends CordovaPlugin {
             Log.d(TAG, "onActivityResult handled by IABUtil.");
         }
     }
-    
+
     /** Verifies the developer payload of a purchase. */
     boolean verifyDeveloperPayload(Purchase p) {
         @SuppressWarnings("unused")
-		String payload = p.getDeveloperPayload();
-        
+        String payload = p.getDeveloperPayload();
+
         /*
          * TODO: verify that the developer payload of the purchase is correct. It will be
          * the same one that you sent when initiating the purchase.
-         * 
-         * WARNING: Locally generating a random string when starting a purchase and 
-         * verifying it here might seem like a good approach, but this will fail in the 
-         * case where the user purchases an item on one device and then uses your app on 
+         *
+         * WARNING: Locally generating a random string when starting a purchase and
+         * verifying it here might seem like a good approach, but this will fail in the
+         * case where the user purchases an item on one device and then uses your app on
          * a different device, because on the other device you will not have access to the
          * random string you originally generated.
          *
          * So a good developer payload has these characteristics:
-         * 
+         *
          * 1. If two different users purchase an item, the payload is different between them,
          *    so that one user's purchase can't be replayed to another user.
-         * 
+         *
          * 2. The payload must be such that you can verify it even when the app wasn't the
-         *    one who initiated the purchase flow (so that items purchased by the user on 
+         *    one who initiated the purchase flow (so that items purchased by the user on
          *    one device work on other devices owned by the user).
-         * 
+         *
          * Using your own server to store and verify developer payloads across app
          * installations is recommended.
          */
-        
+
         return true;
     }
-    
+
     // We're being destroyed. It's important to dispose of the helper here!
     @Override
     public void onDestroy() {
-    	super.onDestroy();
-    	
-    	// very important:
-    	Log.d(TAG, "Destroying helper.");
-    	if (mHelper != null) {
-    		mHelper.dispose();
-    		mHelper = null;
-    	}
+        super.onDestroy();
+
+        // very important:
+        Log.d(TAG, "Destroying helper.");
+        if (mHelper != null) {
+            mHelper.dispose();
+            mHelper = null;
+        }
     }
-    
+
 }

--- a/src/android/com/smartmobilesoftware/inappbilling/InAppBillingPlugin.java
+++ b/src/android/com/smartmobilesoftware/inappbilling/InAppBillingPlugin.java
@@ -227,7 +227,10 @@ public class InAppBillingPlugin extends CordovaPlugin {
         // Convert the java list to json
         JSONArray jsonPurchaseList = new JSONArray();
         for (Purchase p : purchaseList) {
-            jsonPurchaseList.put(new JSONObject(p.getOriginalJson()));
+            JSONObject purchaseJsonObject = new JSONObject(p.getOriginalJson());
+            purchaseJsonObject.put("signature", p.getSignature());
+            purchaseJsonObject.put("receipt", p.getOriginalJson().toString());
+            jsonPurchaseList.put(purchaseJsonObject);
         }
 
         return jsonPurchaseList;

--- a/www/inappbilling.js
+++ b/www/inappbilling.js
@@ -11,81 +11,81 @@ var InAppBilling = function () {
 };
 
 InAppBilling.prototype.init = function (success, fail, options, skus) {
-	options || (options = {});
+    options || (options = {});
 
-	this.options = {
-		showLog: options.showLog !== false
-	};
-	
-	if (this.options.showLog) {
-		log('setup ok');
-	}
-	
-	var hasSKUs = false;
-	//Optional Load SKUs to Inventory.
-	if(typeof skus !== "undefined"){
-		if (typeof skus === "string") {
-        	skus = [skus];
-    	}
-    	if (skus.length > 0) {
-        	if (typeof skus[0] !== 'string') {
-            	var msg = 'invalid productIds: ' + JSON.stringify(skus);
-            	if (this.options.showLog) {
-            		log(msg);
-            	}
-				fail(msg);
-            	return;
-        	}
-        	if (this.options.showLog) {
-        		log('load ' + JSON.stringify(skus));
-        	}
-			hasSKUs = true;
-    	}
-	}
-	
-	if(hasSKUs){
-		return cordova.exec(success, fail, "InAppBillingPlugin", "init", [skus]);
+    this.options = {
+        showLog: options.showLog !== false
+    };
+
+    if (this.options.showLog) {
+        log('setup ok');
+    }
+
+    var hasSKUs = false;
+    //Optional Load SKUs to Inventory.
+    if(typeof skus !== "undefined"){
+        if (typeof skus === "string") {
+            skus = [skus];
+        }
+        if (skus.length > 0) {
+            if (typeof skus[0] !== 'string') {
+                var msg = 'invalid productIds: ' + JSON.stringify(skus);
+                if (this.options.showLog) {
+                    log(msg);
+                }
+                fail(msg);
+                return;
+            }
+            if (this.options.showLog) {
+                log('load ' + JSON.stringify(skus));
+            }
+            hasSKUs = true;
+        }
+    }
+
+    if(hasSKUs){
+        return cordova.exec(success, fail, "InAppBillingPlugin", "init", [skus]);
     }else {
         //No SKUs
-		return cordova.exec(success, fail, "InAppBillingPlugin", "init", []);
+        return cordova.exec(success, fail, "InAppBillingPlugin", "init", []);
     }
 };
 InAppBilling.prototype.getPurchases = function (success, fail) {
-	if (this.options.showLog) {
-		log('getPurchases called!');
-	}
-	return cordova.exec(success, fail, "InAppBillingPlugin", "getPurchases", ["null"]);
+    if (this.options.showLog) {
+        log('getPurchases called!');
+    }
+    return cordova.exec(success, fail, "InAppBillingPlugin", "getPurchases", ["null"]);
 };
 InAppBilling.prototype.buy = function (success, fail, productId) {
-	if (this.options.showLog) {
-		log('buy called!');
-	}
-	return cordova.exec(success, fail, "InAppBillingPlugin", "buy", [productId]);
+    if (this.options.showLog) {
+        log('buy called!');
+    }
+    return cordova.exec(success, fail, "InAppBillingPlugin", "buy", [productId]);
 };
 InAppBilling.prototype.subscribe = function (success, fail, productId) {
-	if (this.options.showLog) {
-		log('subscribe called!');
-	}
-	return cordova.exec(success, fail, "InAppBillingPlugin", "subscribe", [productId]);
+    if (this.options.showLog) {
+        log('subscribe called!');
+    }
+    return cordova.exec(success, fail, "InAppBillingPlugin", "subscribe", [productId]);
 };
 InAppBilling.prototype.consumePurchase = function (success, fail, productId) {
-	if (this.options.showLog) {
-		log('consumePurchase called!');
-	}
-	return cordova.exec(success, fail, "InAppBillingPlugin", "consumePurchase", [productId]);
+    if (this.options.showLog) {
+        log('consumePurchase called!');
+    }
+    return cordova.exec(success, fail, "InAppBillingPlugin", "consumePurchase", [productId]);
 };
 InAppBilling.prototype.getAvailableProducts = function (success, fail) {
-	if (this.options.showLog) {
-		log('getAvailableProducts called!');
-	}
-	return cordova.exec(success, fail, "InAppBillingPlugin", "getAvailableProducts", ["null"]);
+    if (this.options.showLog) {
+        log('getAvailableProducts called!');
+    }
+    return cordova.exec(success, fail, "InAppBillingPlugin", "getAvailableProducts", ["null"]);
 };
 InAppBilling.prototype.getProductDetails = function (success, fail, skus) {
-	if (this.options.showLog) {
-		log('getProductDetails called!');
-	}
-	
-	if (typeof skus === "string") {
+    if (this.options.showLog) {
+        log('getProductDetails called!');
+    }
+
+    if (typeof skus === "string") {
         skus = [skus];
     }
     if (!skus.length) {
@@ -95,13 +95,13 @@ InAppBilling.prototype.getProductDetails = function (success, fail, skus) {
         if (typeof skus[0] !== 'string') {
             var msg = 'invalid productIds: ' + JSON.stringify(skus);
             log(msg);
-			fail(msg);
+            fail(msg);
             return;
         }
         if (this.options.showLog) {
-        	log('load ' + JSON.stringify(skus));
+            log('load ' + JSON.stringify(skus));
         }
-		return cordova.exec(success, fail, "InAppBillingPlugin", "getProductDetails", [skus]);
+        return cordova.exec(success, fail, "InAppBillingPlugin", "getProductDetails", [skus]);
     }
 };
 


### PR DESCRIPTION
Add `signature`, `receipt` to purchase JSON.

Application may crash in between buying and server-side verification.
To continue consuming purchases, these fields are necessity.

First commit 935e71235501abd55be922325490f3e3ab46479a does just fix indentation. See diff with `?w=1` query. https://github.com/poiuytrez/AndroidInAppBilling/commit/935e71235501abd55be922325490f3e3ab46479a?w=1



