### PR TITLE
Updated IabHelper class to prevent NullPointer exception when google

### DIFF
--- a/src/android/com/smartmobilesoftware/util/IabHelper.java
+++ b/src/android/com/smartmobilesoftware/util/IabHelper.java
@@ -264,7 +264,8 @@ public class IabHelper {
 
         Intent serviceIntent = new Intent("com.android.vending.billing.InAppBillingService.BIND");
         serviceIntent.setPackage("com.android.vending");
-        if (!mContext.getPackageManager().queryIntentServices(serviceIntent, 0).isEmpty()) {
+        List service = mContext.getPackageManager().queryIntentServices(serviceIntent, 0);
+        if (service != null && !service.isEmpty()) {
             // service available to handle that Intent
             mContext.bindService(serviceIntent, mServiceConn, Context.BIND_AUTO_CREATE);
         }


### PR DESCRIPTION
Updated IabHelper class to prevent NullPointer exception when google play is not installed (For on genymotion and other vm devices)