### PR TITLE
refreshPurchases method added

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,14 @@ parameters
 
 * error : The error callback.
 
+#### Force refresh owned products
+The plugin retrieve the list of owned products from Google Play during the initialisation and cache the it internally, the getPurchase method returns the local copy of this list.   
+If for some reason you have to force refresh the list of the owned products, use the refreshPurchases method.
+
+	inappbilling.refreshPurchases(success, fail)
+
+The parameters are exactly the same, the success callback provides also an array with the owned products.
+
 #### Purchase
 Purchase an item. You cannot buy an item that you already own.
 

--- a/src/android/com/smartmobilesoftware/inappbilling/InAppBillingPlugin.java
+++ b/src/android/com/smartmobilesoftware/inappbilling/InAppBillingPlugin.java
@@ -229,7 +229,10 @@ public class InAppBillingPlugin extends CordovaPlugin {
         // Convert the java list to json
         JSONArray jsonPurchaseList = new JSONArray();
         for (Purchase p : purchaseList) {
-	        jsonPurchaseList.put(new JSONObject(p.getOriginalJson()));
+            JSONObject purchaseJsonObject = new JSONObject(p.getOriginalJson());
+            purchaseJsonObject.put("signature", p.getSignature());
+            purchaseJsonObject.put("receipt", p.getOriginalJson().toString());
+            jsonPurchaseList.put(purchaseJsonObject);
         }
 
         return jsonPurchaseList;

--- a/src/android/com/smartmobilesoftware/inappbilling/InAppBillingPlugin.java
+++ b/src/android/com/smartmobilesoftware/inappbilling/InAppBillingPlugin.java
@@ -65,7 +65,9 @@ public class InAppBillingPlugin extends CordovaPlugin {
 				}
 				// Initialize
 				init(sku);
-			} else if ("getPurchases".equals(action)) {
+			} else if ("refreshPurchases".equals(action)) {
+                mHelper.queryInventoryAsync(mGotInventoryListener);
+            } else if ("getPurchases".equals(action)) {
 				// Get the list of purchases
 				JSONArray jsonSkuList = new JSONArray();
 				jsonSkuList = getPurchases();

--- a/www/inappbilling.js
+++ b/www/inappbilling.js
@@ -56,6 +56,20 @@ InAppBilling.prototype.getPurchases = function (success, fail) {
 	}
 	return cordova.exec(success, fail, "InAppBillingPlugin", "getPurchases", ["null"]);
 };
+InAppBilling.prototype.refreshPurchases = function (success, fail) {
+	if (this.options.showLog) {
+		log('refreshPurchases called!');
+	}
+
+	var self = this;
+	var onSuccess = function() {
+		self.getPurchases(function(purchases) {
+			success(purchases);
+		}, fail);
+	};
+
+	return cordova.exec(onSuccess, fail, "InAppBillingPlugin", "refreshPurchases", ["null"]);
+};
 InAppBilling.prototype.buy = function (success, fail, productId) {
 	if (this.options.showLog) {
 		log('buy called!');


### PR DESCRIPTION
Hi @poiuytrez,

After using this plugin for some time, I noticed that some people for a mysterious reason had their payment processed successfully on the play store but not on my side.
After some search, I found out that the success or fail callback of the buy method has never been called for these people and the product is not available in the list retrieved with the getPurchases method.

The only solution I currently found to fix this problem is to force refresh the list of owned products after a certain amount of time without any response from the callbacks and then consume/process the owned products if there is any.

The intend of this PR is to add the refreshPurchases method in order to be able to force refresh from the play store the list of the owned products.
I also added the signature and receipt in the objects of the owned product list, that way the products can be processed (The success callback of the buy method already expose the signature and receipt of the purchased product).

Tested and works perfectly