### PR TITLE
Code refactored for a better handling of async callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,11 @@ The list of the available product(s) in inventory.
 
 * error : The error callback.
 
+#### Check if the Play Store purchase view is open
+
+		inappbilling.isPurchaseOpen(success)
+* success : The success callback. It provides a boolean
+
 
 Quick example
 ---------------

--- a/plugin.xml
+++ b/plugin.xml
@@ -56,5 +56,6 @@
 		<source-file src="src/android/com/smartmobilesoftware/util/Purchase.java" target-dir="src/com/smartmobilesoftware/util" />
 		<source-file src="src/android/com/smartmobilesoftware/util/Security.java" target-dir="src/com/smartmobilesoftware/util" />
 		<source-file src="src/android/com/smartmobilesoftware/util/SkuDetails.java" target-dir="src/com/smartmobilesoftware/util" />
+        <source-file src="src/android/com/smartmobilesoftware/util/Action.java" target-dir="src/com/smartmobilesoftware/util" />
     </platform>
 </plugin>

--- a/src/android/com/smartmobilesoftware/inappbilling/InAppBillingPlugin.java
+++ b/src/android/com/smartmobilesoftware/inappbilling/InAppBillingPlugin.java
@@ -21,99 +21,83 @@ import com.smartmobilesoftware.util.IabHelper;
 import com.smartmobilesoftware.util.IabResult;
 import com.smartmobilesoftware.util.Inventory;
 import com.smartmobilesoftware.util.SkuDetails;
+import com.smartmobilesoftware.util.Action;
 
 import android.content.Intent;
 import android.util.Log;
 
 public class InAppBillingPlugin extends CordovaPlugin {
-	private final Boolean ENABLE_DEBUG_LOGGING = true;
-	private final String TAG = "CORDOVA_BILLING";
+	private final Boolean      ENABLE_DEBUG_LOGGING = true;
+    public static final int    RC_REQUEST = 10001; // (arbitrary) request code for the purchase flow
 
-
-    // (arbitrary) request code for the purchase flow
-    static final int RC_REQUEST = 10001;
+    public final String        TAG = "CORDOVA_BILLING";
 
     // The helper object
-    IabHelper mHelper;
+    public  IabHelper           mHelper;
 
     // A quite up to date inventory of available items and purchase items
-    Inventory myInventory;
+    public  Inventory           myInventory;
 
-    CallbackContext callbackContext;
+    // Plugin initialized ?
+    boolean                     initialized = false;
+
+    // Activity open
+    boolean                     activityOpen = false;
 
 	@Override
 	/**
 	 * Called by each javascript plugin function
 	 */
 	public boolean execute(String action, JSONArray data, final CallbackContext callbackContext) {
-		this.callbackContext = callbackContext;
-		// Check if the action has a handler
-		Boolean isValidAction = true;
-		
-		try {
-			// Action selector
-			if ("init".equals(action)) {
-				final List<String> sku = new ArrayList<String>();
-				if(data.length() > 0){
-					JSONArray jsonSkuList = new JSONArray(data.getString(0));
-					int len = jsonSkuList.length();
-					Log.d(TAG, "Num SKUs Found: "+len);
-	   			 for (int i=0;i<len;i++){
-	    				sku.add(jsonSkuList.get(i).toString());
-						Log.d(TAG, "Product SKU Added: "+jsonSkuList.get(i).toString());
-	   			 }
-				}
-				// Initialize
-				init(sku);
-			} else if ("refreshPurchases".equals(action)) {
-                mHelper.queryInventoryAsync(mGotInventoryListener);
-            } else if ("getPurchases".equals(action)) {
-				// Get the list of purchases
-				JSONArray jsonSkuList = new JSONArray();
-				jsonSkuList = getPurchases();
-	            // Call the javascript back
-	            callbackContext.success(jsonSkuList);
-			} else if ("buy".equals(action)) {
-				// Buy an item
-				// Get Product Id 
-				final String sku = data.getString(0);
-				buy(sku);
-			} else if ("subscribe".equals(action)) {
-				// Subscribe to an item
-				// Get Product Id 
-				final String sku = data.getString(0);
-				subscribe(sku);
-			} else if ("consumePurchase".equals(action)) {
-				consumePurchase(data);
-			} else if ("getAvailableProducts".equals(action)) {
-				// Get the list of purchases
-				JSONArray jsonSkuList = new JSONArray();
-				jsonSkuList = getAvailableProducts();
-	            // Call the javascript back
-	            callbackContext.success(jsonSkuList);
-			} else if ("getProductDetails".equals(action)) {
-				JSONArray jsonSkuList = new JSONArray(data.getString(0));
-				final List<String> sku = new ArrayList<String>();			
-				int len = jsonSkuList.length();
-				Log.d(TAG, "Num SKUs Found: "+len);
-   			 for (int i=0;i<len;i++){
-    				sku.add(jsonSkuList.get(i).toString());
-					Log.d(TAG, "Product SKU Added: "+jsonSkuList.get(i).toString());
-   			 }
-				getProductDetails(sku);				
-			} else {
-				// No handler for the action
-				isValidAction = false;
-			}
-		} catch (IllegalStateException e){
-			callbackContext.error(e.getMessage());
-		} catch (JSONException e){
-			callbackContext.error(e.getMessage());
-		}
+
+        try {
+            // Action selector
+            if ("init".equals(action)) {
+                final List<String> sku = new ArrayList<String>();
+                if(data.length() > 0){
+                    JSONArray jsonSkuList = new JSONArray(data.getString(0));
+                    int len = jsonSkuList.length();
+                    Log.d(TAG, "Num SKUs Found: "+len);
+                 for (int i=0;i<len;i++){
+                        sku.add(jsonSkuList.get(i).toString());
+                        Log.d(TAG, "Product SKU Added: "+jsonSkuList.get(i).toString());
+                 }
+                }
+                // Initialize
+                init(sku, callbackContext);
+                return true;
+            } else if ("isPurchaseOpen".equals(action)) {
+                if (activityOpen == true) {
+                    callbackContext.success("true");
+                } else {
+                    callbackContext.success("false");
+                }
+                return true;
+            } else {
+                if (initialized == false) {
+                    throw new IllegalStateException("Billing plugin was not initialized");
+                }
+                Action actionInstance = new Action(action, data, this, mHelper, callbackContext);
+                return actionInstance.execute();
+            }
+        } catch (IllegalStateException e){
+            callbackContext.error(e.getMessage());
+        } catch (JSONException e){
+            callbackContext.error(e.getMessage());
+        }
 
 		// Method not found
-		return isValidAction;
+		return false;
 	}
+
+    public void startActivity() {
+        this.cordova.setActivityResultCallback(this);
+        activityOpen = true;
+    }
+
+    public void endActivity() {
+        activityOpen = false;
+    }
 
     private String getPublicKey() {
         int billingKeyFromParam = cordova.getActivity().getResources().getIdentifier("billing_key_param", "string", cordova.getActivity().getPackageName());
@@ -127,7 +111,7 @@ public class InAppBillingPlugin extends CordovaPlugin {
     }
 
 	// Initialize the plugin
-	private void init(final List<String> skus){
+	private void init(final List<String> skus, final CallbackContext callbackContext){
 		Log.d(TAG, "init start");
 
         String base64EncodedPublicKey = getPublicKey();
@@ -146,6 +130,8 @@ public class InAppBillingPlugin extends CordovaPlugin {
         // will be called once setup completes.
         Log.d(TAG, "Starting setup.");
 
+        final InAppBillingPlugin plugin = this;
+
         mHelper.startSetup(new IabHelper.OnIabSetupFinishedListener() {
             public void onIabSetupFinished(IabResult result) {
                 Log.d(TAG, "Setup finished.");
@@ -162,257 +148,26 @@ public class InAppBillingPlugin extends CordovaPlugin {
                 }
 
                 // Hooray, IAB is fully set up. Now, let's get an inventory of stuff we own.
+                initialized = true;
+
+                 Action actionInstance = new Action(plugin, mHelper, callbackContext);
                 if(skus.size() <= 0){
 					Log.d(TAG, "Setup successful. Querying inventory.");
-                	mHelper.queryInventoryAsync(mGotInventoryListener);
-				}else{
+                	actionInstance.refreshPurchases();
+				} else{
 					Log.d(TAG, "Setup successful. Querying inventory w/ SKUs.");
-					mHelper.queryInventoryAsync(true, skus, mGotInventoryListener);
+                    actionInstance.refreshPurchases(skus);
 				}
-            }			
+
+
+            }
         });
     }
-	
-	// Buy an item
-	private void buy(final String sku){
-		/* TODO: for security, generate your payload here for verification. See the comments on 
-         *        verifyDeveloperPayload() for more info. Since this is a sample, we just use 
-         *        an empty string, but on a production app you should generate this. */
-		final String payload = "";
-		
-		if (mHelper == null){
-			callbackContext.error("Billing plugin was not initialized");
-			return;
-		}
-		
-		this.cordova.setActivityResultCallback(this);
-		
-		mHelper.launchPurchaseFlow(cordova.getActivity(), sku, RC_REQUEST, 
-                mPurchaseFinishedListener, payload);
-
-	}
-	
-	// Buy an item
-	private void subscribe(final String sku){
-		if (mHelper == null){
-			callbackContext.error("Billing plugin was not initialized");
-			return;
-		}
-		if (!mHelper.subscriptionsSupported()) {
-            callbackContext.error("Subscriptions not supported on your device yet. Sorry!");
-            return;
-        }
-		
-		/* TODO: for security, generate your payload here for verification. See the comments on 
-         *        verifyDeveloperPayload() for more info. Since this is a sample, we just use 
-         *        an empty string, but on a production app you should generate this. */
-		final String payload = "";
-		
-		
-		
-		this.cordova.setActivityResultCallback(this);
-        Log.d(TAG, "Launching purchase flow for subscription.");
-
-		mHelper.launchPurchaseFlow(cordova.getActivity(), sku, IabHelper.ITEM_TYPE_SUBS, RC_REQUEST, mPurchaseFinishedListener, payload);   
-	}
-	
-
-	// Get the list of purchases
-	private JSONArray getPurchases() throws JSONException {
-		// Get the list of owned items
-		if(myInventory == null){
-			callbackContext.error("Billing plugin was not initialized");
-			return new JSONArray();
-		}
-        List<Purchase>purchaseList = myInventory.getAllPurchases();
-
-        // Convert the java list to json
-        JSONArray jsonPurchaseList = new JSONArray();
-        for (Purchase p : purchaseList) {
-            JSONObject purchaseJsonObject = new JSONObject(p.getOriginalJson());
-            purchaseJsonObject.put("signature", p.getSignature());
-            purchaseJsonObject.put("receipt", p.getOriginalJson().toString());
-            jsonPurchaseList.put(purchaseJsonObject);
-        }
-
-        return jsonPurchaseList;
-
-	}
-
-	// Get the list of available products
-	private JSONArray getAvailableProducts(){
-		// Get the list of owned items
-		if(myInventory == null){
-			callbackContext.error("Billing plugin was not initialized");
-			return new JSONArray();
-		}
-        List<SkuDetails>skuList = myInventory.getAllProducts();
-        
-		// Convert the java list to json
-	    JSONArray jsonSkuList = new JSONArray();
-		try{
-	        for (SkuDetails sku : skuList) {
-				Log.d(TAG, "SKUDetails: Title: "+sku.getTitle());
-	        	jsonSkuList.put(sku.toJson());
-	        }
-		}catch (JSONException e){
-			callbackContext.error(e.getMessage());
-		}
-		return jsonSkuList;
-	}
-
-	//Get SkuDetails for skus
-	private void getProductDetails(final List<String> skus){
-		if (mHelper == null){
-			callbackContext.error("Billing plugin was not initialized");
-			return;
-		}
-
-		Log.d(TAG, "Beginning Sku(s) Query!");
-		mHelper.queryInventoryAsync(true, skus, mGotDetailsListener);
-	}
-	
-	// Consume a purchase
-	private void consumePurchase(JSONArray data) throws JSONException{
-		
-		if (mHelper == null){
-			callbackContext.error("Did you forget to initialize the plugin?");
-			return;
-		} 
-		
-		String sku = data.getString(0);
-		
-		// Get the purchase from the inventory
-		Purchase purchase = myInventory.getPurchase(sku);
-		if (purchase != null)
-			// Consume it
-			mHelper.consumeAsync(purchase, mConsumeFinishedListener);
-		else
-			callbackContext.error(sku + " is not owned so it cannot be consumed");
-	}
-	
-	// Listener that's called when we finish querying the items and subscriptions we own
-    IabHelper.QueryInventoryFinishedListener mGotInventoryListener = new IabHelper.QueryInventoryFinishedListener() {
-        public void onQueryInventoryFinished(IabResult result, Inventory inventory) {
-        	Log.d(TAG, "Inside mGotInventoryListener");
-        	if (hasErrorsAndUpdateInventory(result, inventory)) return;
-
-            Log.d(TAG, "Query inventory was successful.");
-            callbackContext.success();
-            
-        }
-    };
-    // Listener that's called when we finish querying the details
-    IabHelper.QueryInventoryFinishedListener mGotDetailsListener = new IabHelper.QueryInventoryFinishedListener() {
-        public void onQueryInventoryFinished(IabResult result, Inventory inventory) {
-            Log.d(TAG, "Inside mGotDetailsListener");
-            if (hasErrorsAndUpdateInventory(result, inventory)) return;
-
-            Log.d(TAG, "Query details was successful.");
-
-            List<SkuDetails>skuList = inventory.getAllProducts();
-        
-            // Convert the java list to json
-            JSONArray jsonSkuList = new JSONArray();
-            try {
-                for (SkuDetails sku : skuList) {
-                    Log.d(TAG, "SKUDetails: Title: "+sku.getTitle());
-                    jsonSkuList.put(sku.toJson());
-                }
-            } catch (JSONException e) {
-                callbackContext.error(e.getMessage());
-            }
-            callbackContext.success(jsonSkuList);
-        }
-    };
-
-    // Check if there is any errors in the iabResult and update the inventory
-    private Boolean hasErrorsAndUpdateInventory(IabResult result, Inventory inventory){
-    	if (result.isFailure()) {
-        	callbackContext.error("Failed to query inventory: " + result);
-        	return true;
-        }
-        
-        // Have we been disposed of in the meantime? If so, quit.
-        if (mHelper == null) {
-        	callbackContext.error("The billing helper has been disposed");
-        	return true;
-        }
-        
-        // Update the inventory
-        myInventory = inventory;
-        
-        return false;
-    }
-    
-    // Callback for when a purchase is finished
-    IabHelper.OnIabPurchaseFinishedListener mPurchaseFinishedListener = new IabHelper.OnIabPurchaseFinishedListener() {
-        public void onIabPurchaseFinished(IabResult result, Purchase purchase) {
-            Log.d(TAG, "Purchase finished: " + result + ", purchase: " + purchase);
-            
-            // Have we been disposed of in the meantime? If so, quit.
-            if (mHelper == null) {
-            	callbackContext.error("The billing helper has been disposed");
-            }
-            
-            if (result.isFailure()) {
-            	callbackContext.error("Error purchasing: " + result);
-                return;
-            }
-            
-            if (!verifyDeveloperPayload(purchase)) {
-            	callbackContext.error("Error purchasing. Authenticity verification failed.");
-                return;
-            }
-
-            Log.d(TAG, "Purchase successful.");
-            
-            // add the purchase to the inventory
-            myInventory.addPurchase(purchase);
-            
-            // append the purchase signature & receipt to the json
-            try {
-                JSONObject purchaseJsonObject = new JSONObject(purchase.getOriginalJson());
-                purchaseJsonObject.put("signature", purchase.getSignature());
-                purchaseJsonObject.put("receipt", purchase.getOriginalJson().toString());
-                callbackContext.success(purchaseJsonObject);
-            } catch (JSONException e) {
-                callbackContext.error("Could not create JSON object from purchase object");
-            }
-
-        }
-    };
-    
-    // Called when consumption is complete
-    IabHelper.OnConsumeFinishedListener mConsumeFinishedListener = new IabHelper.OnConsumeFinishedListener() {
-        public void onConsumeFinished(Purchase purchase, IabResult result) {
-            Log.d(TAG, "Consumption finished. Purchase: " + purchase + ", result: " + result);
-
-            // We know this is the "gas" sku because it's the only one we consume,
-            // so we don't check which sku was consumed. If you have more than one
-            // sku, you probably should check...
-            if (result.isSuccess()) {
-                // successfully consumed, so we apply the effects of the item in our
-                // game world's logic
-            	
-                // remove the item from the inventory
-            	myInventory.erasePurchase(purchase.getSku());
-                Log.d(TAG, "Consumption successful. .");
-                
-                callbackContext.success(purchase.getOriginalJson());
-                
-            }
-            else {
-                callbackContext.error("Error while consuming: " + result);
-            }
-            
-        }
-    };
     
     @Override
 	public void onActivityResult(int requestCode, int resultCode, Intent data) {
         Log.d(TAG, "onActivityResult(" + requestCode + "," + resultCode + "," + data);
-
+        this.endActivity();
         // Pass on the activity result to the helper for handling
         if (!mHelper.handleActivityResult(requestCode, resultCode, data)) {
             // not handled, so handle it ourselves (here's where you'd
@@ -423,37 +178,6 @@ public class InAppBillingPlugin extends CordovaPlugin {
         else {
             Log.d(TAG, "onActivityResult handled by IABUtil.");
         }
-    }
-    
-    /** Verifies the developer payload of a purchase. */
-    boolean verifyDeveloperPayload(Purchase p) {
-        @SuppressWarnings("unused")
-		String payload = p.getDeveloperPayload();
-        
-        /*
-         * TODO: verify that the developer payload of the purchase is correct. It will be
-         * the same one that you sent when initiating the purchase.
-         * 
-         * WARNING: Locally generating a random string when starting a purchase and 
-         * verifying it here might seem like a good approach, but this will fail in the 
-         * case where the user purchases an item on one device and then uses your app on 
-         * a different device, because on the other device you will not have access to the
-         * random string you originally generated.
-         *
-         * So a good developer payload has these characteristics:
-         * 
-         * 1. If two different users purchase an item, the payload is different between them,
-         *    so that one user's purchase can't be replayed to another user.
-         * 
-         * 2. The payload must be such that you can verify it even when the app wasn't the
-         *    one who initiated the purchase flow (so that items purchased by the user on 
-         *    one device work on other devices owned by the user).
-         * 
-         * Using your own server to store and verify developer payloads across app
-         * installations is recommended.
-         */
-        
-        return true;
     }
     
     // We're being destroyed. It's important to dispose of the helper here!

--- a/src/android/com/smartmobilesoftware/util/Action.java
+++ b/src/android/com/smartmobilesoftware/util/Action.java
@@ -1,0 +1,350 @@
+package com.smartmobilesoftware.util;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.json.JSONException;
+
+import org.apache.cordova.CallbackContext;
+
+import com.smartmobilesoftware.inappbilling.InAppBillingPlugin;
+import com.smartmobilesoftware.util.Purchase;
+import com.smartmobilesoftware.util.IabHelper;
+import com.smartmobilesoftware.util.IabResult;
+import com.smartmobilesoftware.util.Inventory;
+import com.smartmobilesoftware.util.SkuDetails;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import android.content.Intent;
+import android.util.Log;
+
+/**
+ * Represents an action (method call)
+ */
+public class Action {
+	String 				action;
+	JSONArray 			data;
+	InAppBillingPlugin 	plugin;
+	IabHelper 			mHelper;
+	CallbackContext 	callbackContext;
+
+
+	public Action(String action, JSONArray data, InAppBillingPlugin plugin, IabHelper mHelper, CallbackContext callbackContext) {
+		this.action = action;
+		this.data = data;
+		this.plugin = plugin;
+		this.mHelper = mHelper;
+		this.callbackContext = callbackContext;
+	}
+
+	public Action(InAppBillingPlugin plugin, IabHelper mHelper, CallbackContext callbackContext) {
+		this.plugin = plugin;
+		this.mHelper = mHelper;
+		this.callbackContext = callbackContext;
+	}
+
+	public boolean execute() throws JSONException, IllegalStateException  {
+		if ("refreshPurchases".equals(action)) {
+            mHelper.queryInventoryAsync(mGotInventoryListener);
+        } else if ("getPurchases".equals(action)) {
+			// Get the list of purchases
+			JSONArray jsonSkuList = new JSONArray();
+			jsonSkuList = getPurchases();
+            // Call the javascript back
+            callbackContext.success(jsonSkuList);
+		} else if ("buy".equals(action)) {
+			// Buy an item
+			// Get Product Id 
+			final String sku = data.getString(0);
+			buy(sku);
+		} else if ("subscribe".equals(action)) {
+			// Subscribe to an item
+			// Get Product Id 
+			final String sku = data.getString(0);
+			subscribe(sku);
+		} else if ("consumePurchase".equals(action)) {
+			consumePurchase(data);
+		} else if ("getAvailableProducts".equals(action)) {
+			// Get the list of purchases
+			JSONArray jsonSkuList = new JSONArray();
+			jsonSkuList = getAvailableProducts();
+            // Call the javascript back
+            callbackContext.success(jsonSkuList);
+		} else if ("getProductDetails".equals(action)) {
+			JSONArray jsonSkuList = new JSONArray(data.getString(0));
+			final List<String> sku = new ArrayList<String>();			
+			int len = jsonSkuList.length();
+			Log.d(plugin.TAG, "Num SKUs Found: "+len);
+			 for (int i=0;i<len;i++){
+				sku.add(jsonSkuList.get(i).toString());
+				Log.d(plugin.TAG, "Product SKU Added: "+jsonSkuList.get(i).toString());
+			 }
+			getProductDetails(sku);				
+		} else {
+			return false;
+		}
+		return true;
+	}
+
+	/*********************************** ACTIONS ********************************/
+
+
+	public void refreshPurchases(final List<String> skus) {
+		mHelper.queryInventoryAsync(true, skus, mGotInventoryListener);
+	}
+
+	public void refreshPurchases() {
+		mHelper.queryInventoryAsync(mGotInventoryListener);
+	}
+
+	// Buy an item
+	private void buy(final String sku){
+		/* TODO: for security, generate your payload here for verification. See the comments on 
+         *        verifyDeveloperPayload() for more info. Since this is a sample, we just use 
+         *        an empty string, but on a production app you should generate this. */
+		final String payload = "";
+		
+		plugin.startActivity();
+		
+		mHelper.launchPurchaseFlow(plugin.cordova.getActivity(), sku, plugin.RC_REQUEST, 
+                mPurchaseFinishedListener, payload);
+
+	}
+	
+	// Buy an item
+	private void subscribe(final String sku){
+		if (!mHelper.subscriptionsSupported()) {
+            callbackContext.error("Subscriptions not supported on your device yet. Sorry!");
+            return;
+        }
+		
+		/* TODO: for security, generate your payload here for verification. See the comments on 
+         *        verifyDeveloperPayload() for more info. Since this is a sample, we just use 
+         *        an empty string, but on a production app you should generate this. */
+		final String payload = "";
+		
+		plugin.startActivity();
+        Log.d(plugin.TAG, "Launching purchase flow for subscription.");
+
+		mHelper.launchPurchaseFlow(plugin.cordova.getActivity(), sku, IabHelper.ITEM_TYPE_SUBS, plugin.RC_REQUEST, mPurchaseFinishedListener, payload);   
+	}
+	
+
+	// Get the list of purchases
+	private JSONArray getPurchases() throws JSONException {
+        List<Purchase>purchaseList = plugin.myInventory.getAllPurchases();
+
+        // Convert the java list to json
+        JSONArray jsonPurchaseList = new JSONArray();
+        for (Purchase p : purchaseList) {
+            JSONObject purchaseJsonObject = new JSONObject(p.getOriginalJson());
+            purchaseJsonObject.put("signature", p.getSignature());
+            purchaseJsonObject.put("receipt", p.getOriginalJson().toString());
+            jsonPurchaseList.put(purchaseJsonObject);
+        }
+
+        return jsonPurchaseList;
+
+	}
+
+	// Get the list of available products
+	private JSONArray getAvailableProducts(){
+		// Get the list of owned items
+		if(plugin.myInventory == null){
+			callbackContext.error("Billing plugin was not initialized");
+			return new JSONArray();
+		}
+        List<SkuDetails>skuList = plugin.myInventory.getAllProducts();
+        
+		// Convert the java list to json
+	    JSONArray jsonSkuList = new JSONArray();
+		try{
+	        for (SkuDetails sku : skuList) {
+				Log.d(plugin.TAG, "SKUDetails: Title: "+sku.getTitle());
+	        	jsonSkuList.put(sku.toJson());
+	        }
+		}catch (JSONException e){
+			callbackContext.error(e.getMessage());
+		}
+		return jsonSkuList;
+	}
+
+	//Get SkuDetails for skus
+	private void getProductDetails(final List<String> skus){
+		Log.d(plugin.TAG, "Beginning Sku(s) Query!");
+		mHelper.queryInventoryAsync(true, skus, mGotDetailsListener);
+	}
+	
+	// Consume a purchase
+	private void consumePurchase(JSONArray data) throws JSONException{	
+		String sku = data.getString(0);
+		
+		// Get the purchase from the inventory
+		Purchase purchase = plugin.myInventory.getPurchase(sku);
+		if (purchase != null)
+			// Consume it
+			mHelper.consumeAsync(purchase, mConsumeFinishedListener);
+		else
+			callbackContext.error(sku + " is not owned so it cannot be consumed");
+	}
+
+
+	/*********************************** PRIVATE METHODS ********************************/
+
+
+	// Check if there is any errors in the iabResult and update the inventory
+    private Boolean hasErrorsAndUpdateInventory(IabResult result, Inventory inventory){
+    	if (result.isFailure()) {
+        	callbackContext.error("Failed to query inventory: " + result);
+        	return true;
+        }
+        
+        // Have we been disposed of in the meantime? If so, quit.
+        if (mHelper == null) {
+        	callbackContext.error("The billing helper has been disposed");
+        	return true;
+        }
+        
+        // Update the inventory
+        plugin.myInventory = inventory;
+        
+        return false;
+    }
+
+    /** Verifies the developer payload of a purchase. */
+    private Boolean verifyDeveloperPayload(Purchase p) {
+        @SuppressWarnings("unused")
+		String payload = p.getDeveloperPayload();
+        
+        /*
+         * TODO: verify that the developer payload of the purchase is correct. It will be
+         * the same one that you sent when initiating the purchase.
+         * 
+         * WARNING: Locally generating a random string when starting a purchase and 
+         * verifying it here might seem like a good approach, but this will fail in the 
+         * case where the user purchases an item on one device and then uses your app on 
+         * a different device, because on the other device you will not have access to the
+         * random string you originally generated.
+         *
+         * So a good developer payload has these characteristics:
+         * 
+         * 1. If two different users purchase an item, the payload is different between them,
+         *    so that one user's purchase can't be replayed to another user.
+         * 
+         * 2. The payload must be such that you can verify it even when the app wasn't the
+         *    one who initiated the purchase flow (so that items purchased by the user on 
+         *    one device work on other devices owned by the user).
+         * 
+         * Using your own server to store and verify developer payloads across app
+         * installations is recommended.
+         */
+        
+        return true;
+    }
+
+
+	/*********************************** LISTENERS ********************************/
+
+
+	// Listener that's called when we finish querying the items and subscriptions we own
+    IabHelper.QueryInventoryFinishedListener mGotInventoryListener = new IabHelper.QueryInventoryFinishedListener() {
+        public void onQueryInventoryFinished(IabResult result, Inventory inventory) {
+        	Log.d(plugin.TAG, "Inside mGotInventoryListener");
+        	if (hasErrorsAndUpdateInventory(result, inventory)) return;
+
+            Log.d(plugin.TAG, "Query inventory was successful.");
+            callbackContext.success();
+            
+        }
+    };
+    // Listener that's called when we finish querying the details
+    IabHelper.QueryInventoryFinishedListener mGotDetailsListener = new IabHelper.QueryInventoryFinishedListener() {
+        public void onQueryInventoryFinished(IabResult result, Inventory inventory) {
+            Log.d(plugin.TAG, "Inside mGotDetailsListener");
+            if (hasErrorsAndUpdateInventory(result, inventory)) return;
+
+            Log.d(plugin.TAG, "Query details was successful.");
+
+            List<SkuDetails>skuList = inventory.getAllProducts();
+        
+            // Convert the java list to json
+            JSONArray jsonSkuList = new JSONArray();
+            try {
+                for (SkuDetails sku : skuList) {
+                    Log.d(plugin.TAG, "SKUDetails: Title: "+sku.getTitle());
+                    jsonSkuList.put(sku.toJson());
+                }
+            } catch (JSONException e) {
+                callbackContext.error(e.getMessage());
+            }
+            callbackContext.success(jsonSkuList);
+        }
+    };
+
+    // Callback for when a purchase is finished
+    IabHelper.OnIabPurchaseFinishedListener mPurchaseFinishedListener = new IabHelper.OnIabPurchaseFinishedListener() {
+        public void onIabPurchaseFinished(IabResult result, Purchase purchase) {
+            Log.d(plugin.TAG, "Purchase finished: " + result + ", purchase: " + purchase);
+            
+            // Have we been disposed of in the meantime? If so, quit.
+            if (mHelper == null) {
+            	callbackContext.error("The billing helper has been disposed");
+            }
+            
+            if (result.isFailure()) {
+            	callbackContext.error("Error purchasing: " + result);
+                return;
+            }
+            
+            if (!verifyDeveloperPayload(purchase)) {
+            	callbackContext.error("Error purchasing. Authenticity verification failed.");
+                return;
+            }
+
+            Log.d(plugin.TAG, "Purchase successful.");
+            
+            // add the purchase to the inventory
+            plugin.myInventory.addPurchase(purchase);
+            
+            // append the purchase signature & receipt to the json
+            try {
+                JSONObject purchaseJsonObject = new JSONObject(purchase.getOriginalJson());
+                purchaseJsonObject.put("signature", purchase.getSignature());
+                purchaseJsonObject.put("receipt", purchase.getOriginalJson().toString());
+                callbackContext.success(purchaseJsonObject);
+            } catch (JSONException e) {
+                callbackContext.error("Could not create JSON object from purchase object");
+            }
+        }
+    };
+    
+    // Called when consumption is complete
+    IabHelper.OnConsumeFinishedListener mConsumeFinishedListener = new IabHelper.OnConsumeFinishedListener() {
+        public void onConsumeFinished(Purchase purchase, IabResult result) {
+            Log.d(plugin.TAG, "Consumption finished. Purchase: " + purchase + ", result: " + result);
+
+            // We know this is the "gas" sku because it's the only one we consume,
+            // so we don't check which sku was consumed. If you have more than one
+            // sku, you probably should check...
+            if (result.isSuccess()) {
+                // successfully consumed, so we apply the effects of the item in our
+                // game world's logic
+            	
+                // remove the item from the inventory
+            	plugin.myInventory.erasePurchase(purchase.getSku());
+                Log.d(plugin.TAG, "Consumption successful. .");
+                
+                callbackContext.success(purchase.getOriginalJson());
+                
+            }
+            else {
+                callbackContext.error("Error while consuming: " + result);
+            }
+            
+        }
+    };
+
+}

--- a/www/inappbilling.js
+++ b/www/inappbilling.js
@@ -118,5 +118,14 @@ InAppBilling.prototype.getProductDetails = function (success, fail, skus) {
 		return cordova.exec(success, fail, "InAppBillingPlugin", "getProductDetails", [skus]);
     }
 };
+InAppBilling.prototype.isPurchaseOpen = function (success, fail) {
+
+	var onSuccess = function(state) {
+		var bool = (state == "true") ? true : false;
+		success(bool);
+	};
+
+	return cordova.exec(onSuccess, fail, "InAppBillingPlugin", "isPurchaseOpen", []);
+}
 
 module.exports = new InAppBilling();


### PR DESCRIPTION
This PR introduce a code refactoring for a better handling of async callbacks.
Previously you couldn't call multiple async functions because the plugin was only keeping track of one callback reference, all the previous methods callbacks were lost...
The code is now cleaner and it works smoothly, this PR aims to fix a problem described here: #102.
A convenience method isPurchaseOpen has been added too in order to check if the Google Play purchase view is currently open.

Plugin deployed in an app in production and everything works perfectly :+1: 