### PR TITLE
Resolve -1008 unknown error for subscribe()

### DIFF
--- a/src/android/com/smartmobilesoftware/util/Action.java
+++ b/src/android/com/smartmobilesoftware/util/Action.java
@@ -129,7 +129,8 @@ public class Action {
 		plugin.startActivity();
         Log.d(plugin.TAG, "Launching purchase flow for subscription.");
 
-		mHelper.launchPurchaseFlow(plugin.cordova.getActivity(), sku, IabHelper.ITEM_TYPE_SUBS, plugin.RC_REQUEST, mPurchaseFinishedListener, payload);   
+		mHelper.launchSubscriptionPurchaseFlow(plugin.cordova.getActivity(), sku, plugin.RC_REQUEST, 
+            mPurchaseFinishedListener);
 	}
 	
 


### PR DESCRIPTION
Using launchPurchaseFlow() in subscribe() can cause "response -1008: Unknown error" in certain cases. This fix updates subscribe() to call launchSubscriptionPurchaseFlow() in IABHelper.java.

Addresses #99 
